### PR TITLE
GOOD-90: Reset error boundary on url change

### DIFF
--- a/src/shared/utils/ErrorBoundary/ErrorComponent.tsx
+++ b/src/shared/utils/ErrorBoundary/ErrorComponent.tsx
@@ -1,9 +1,25 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
+import { FallbackProps } from 'react-error-boundary';
+import { useLocation } from 'react-router-dom';
 
-export const ErrorComponent: FC<{ error: any }> = ({ error }) => (
-  <div>
-    <h1>Error</h1>
-    <h2>Something bad happened</h2>
-    <pre>{error.message}</pre>
-  </div>
-);
+export const ErrorComponent: FC<FallbackProps> = ({
+  error,
+  resetErrorBoundary
+}) => {
+  const location = useLocation();
+  const initialPathname = useRef(location.pathname);
+
+  useEffect(() => {
+    if (location.pathname !== initialPathname.current) {
+      resetErrorBoundary();
+    }
+  }, [initialPathname, location.pathname, resetErrorBoundary]);
+
+  return (
+    <div>
+      <h1>Error</h1>
+      <h2>Something bad happened</h2>
+      <pre>{error.message}</pre>
+    </div>
+  );
+};


### PR DESCRIPTION
I added behavior to the error boundary to reset when a user navigates to a different view. This is so they don't have to hard refresh the browser to dismiss the error.